### PR TITLE
ci: fix self-update workflow permissions

### DIFF
--- a/.github/workflows/self-update.yml
+++ b/.github/workflows/self-update.yml
@@ -12,7 +12,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  workflows: write
 
 jobs:
   self-update:

--- a/.pocket/go.mod
+++ b/.pocket/go.mod
@@ -2,7 +2,7 @@ module pocket
 
 go 1.26.2
 
-require github.com/fredrikaverpil/pocket v0.7.0
+require github.com/fredrikaverpil/pocket v0.7.1
 
 require (
 	golang.org/x/sync v0.20.0 // indirect

--- a/.pocket/go.sum
+++ b/.pocket/go.sum
@@ -1,5 +1,5 @@
-github.com/fredrikaverpil/pocket v0.7.0 h1:xDSNZW1AJ2S95WGFzb/ugOkTcJ8VklwHrgZT2/b8atM=
-github.com/fredrikaverpil/pocket v0.7.0/go.mod h1:uLBWIxampIF0kST8QLvFli3zuWwao0R3zJNYmaMWTrg=
+github.com/fredrikaverpil/pocket v0.7.1 h1:/zOBT68J/CNUbJAUTSnXVYnsbdX9NATol47TQ8TRpa0=
+github.com/fredrikaverpil/pocket v0.7.1/go.mod h1:uLBWIxampIF0kST8QLvFli3zuWwao0R3zJNYmaMWTrg=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=


### PR DESCRIPTION
## Why?

GitHub Actions does not support `workflows` as a workflow-level permission, so the generated self-update workflow is invalid.

## What?

- Remove the invalid `workflows: write` permission from `.github/workflows/self-update.yml`
- Run `./pok self-update -force`
- Run `go-mod-tidy`